### PR TITLE
Bug fixes to get log lines pushed properly to loki

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(PROTOBUF_FOUND)
 		compile_proto(${_file})
 	endforeach()
 else()
-	message("Could not find protobof")
+	message("Could not find protobuf")
 endif()
 
 find_package(CURL REQUIRED)

--- a/include/agent.hpp
+++ b/include/agent.hpp
@@ -66,14 +66,14 @@ public:
 	      Level print_level,
 	      const std::string &remote_host,
 	      std::array<Color, 4> colors)
-	    : labels_{labels}
-	    , flush_interval_{flush_interval}
-	    , max_buffer_{max_buffer}
-	    , log_level_{log_level}
-	    , print_level_{print_level}
-	    , remote_host_{remote_host}
-	    , push_url_{fmt::format("http://{}/loki/api/v1/push", remote_host_)}
-	    , colors_{colors} {
+	    : labels_{labels},
+	      flush_interval_{flush_interval},
+	      max_buffer_{max_buffer},
+	      log_level_{log_level},
+	      print_level_{print_level},
+	      remote_host_{remote_host},
+	      push_url_{fmt::format("http://{}/loki/api/v1/push", remote_host_)},
+	      colors_{colors} {
 		logs_.resize(max_buffer_);
 		cursor_ = logs_.begin();
 	}
@@ -147,18 +147,6 @@ protected:
 	decltype(logs_.begin()) cursor_;
 
 	std::recursive_mutex mutex_{};
-
-	/// \brief Append to `line` escaped string `str`.
-	void escape(std::string &line, const std::string &str) const {
-		line.reserve(str.size());
-		for (auto c : str) {
-			switch (c) {
-			case '\\': line += "\\\\"; break;
-			case '\"': line += "\\\""; break;
-			default: line += c; break;
-			}
-		}
-	}
 
 	/// \brief Handle incoming logs.
 	void log(std::string &&line, Level level) {

--- a/include/detail/utils.hpp
+++ b/include/detail/utils.hpp
@@ -23,4 +23,35 @@ Response post(CURL *curl,
               const std::string &payload,
               ContentType content_type = ContentType::Raw);
 
+/// \brief Convert value (between 0 and 15) to a hexadecimal digit character
+inline char hex_char(char c) {
+	return c < 10 ? (c + '0') : (c - 10 + 'a');
+}
+
+/// \brief Append to `line` JSON escaped string `str`.
+inline void json_escape(std::string &line, const std::string &str) {
+	line.reserve(line.size() + str.size());
+	for (auto c : str) {
+		switch (c) {
+		case '\\': line += "\\\\"; break;
+		case '\"': line += "\\\""; break;
+		case '\b': line += "\\b"; break;
+		case '\f': line += "\\f"; break;
+		case '\n': line += "\\n"; break;
+		case '\r': line += "\\r"; break;
+		case '\t': line += "\\t"; break;
+		default:
+			if (c >= ' ') {
+				line += c;
+				break;
+			} else {
+				line += "\\u00";
+				line += hex_char(c >> 4);
+				line += hex_char(c & 0xF);
+				break;
+			}
+		}
+	}
+}
+
 }  // namespace loki::detail

--- a/include/registry.hpp
+++ b/include/registry.hpp
@@ -24,13 +24,13 @@ public:
 	         Level print_level,
 	         std::string &&remote_host,
 	         std::array<Color, 4> colors)
-	    : labels_{std::move(labels)}
-	    , flush_interval_{flush_interval}
-	    , max_buffer_{max_buffer}
-	    , log_level_{log_level}
-	    , print_level_{print_level}
-	    , remote_host_{std::move(remote_host)}
-	    , colors_{colors} {
+	    : labels_{std::move(labels)},
+	      flush_interval_{flush_interval},
+	      max_buffer_{max_buffer},
+	      log_level_{log_level},
+	      print_level_{print_level},
+	      remote_host_{std::move(remote_host)},
+	      colors_{colors} {
 		curl_global_init(CURL_GLOBAL_DEFAULT);
 		thread_ = std::thread([this]() {
 			while (!close_request_.load()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,11 +9,12 @@ if(GTEST_FOUND)
     ${PROJECT_SOURCE_DIR}/src/query.cpp
     ${PROJECT_SOURCE_DIR}/src/detail/utils.cpp
     ${PROJECT_SOURCE_DIR}/gen/github.com/gogo/protobuf/gogoproto/gogo.pb.cc
-    ${PROJECT_SOURCE_DIR}/gen/google/protobuf/descriptor.pb.cc
-    ${PROJECT_SOURCE_DIR}/gen/google/protobuf/timestamp.pb.cc
+#    ${PROJECT_SOURCE_DIR}/gen/google/protobuf/descriptor.pb.cc
+#    ${PROJECT_SOURCE_DIR}/gen/google/protobuf/timestamp.pb.cc
     ${PROJECT_SOURCE_DIR}/gen/logproto.pb.cc
 
-    ${PROJECT_SOURCE_DIR}/tests/main.cpp)
+    ${PROJECT_SOURCE_DIR}/tests/main.cpp
+    ${PROJECT_SOURCE_DIR}/tests/json_escape_tests.cpp)
 
   set(HEADERS
     ${PROJECT_SOURCE_DIR}/include

--- a/tests/json_escape_tests.cpp
+++ b/tests/json_escape_tests.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include "detail/utils.hpp"
+
+namespace loki::detail {
+
+static std::string test_json_escape(const std::string& input) {
+	std::string output;
+	json_escape(output, input);
+	return output;
+}
+
+TEST(JsonEscapeTest, EmptyString) {
+	EXPECT_EQ("", test_json_escape(""));
+}
+
+TEST(JsonEscapeTest, StringWithoutSpecialCharacters) {
+	EXPECT_EQ("abc 123 +!-", test_json_escape("abc 123 +!-"));
+}
+
+TEST(JsonEscapeTest, StringWithQuotes) {
+	EXPECT_EQ("\\\"hello'", test_json_escape("\"hello'"));
+}
+
+TEST(JsonEscapeTest, StringWithBasicEscapedCharacters) {
+	EXPECT_EQ("test\\\\me", test_json_escape("test\\me"));
+	EXPECT_EQ("test\\bme", test_json_escape("test\bme"));
+	EXPECT_EQ("test\\fme", test_json_escape("test\fme"));
+	EXPECT_EQ("test\\nme", test_json_escape("test\nme"));
+	EXPECT_EQ("test\\rme", test_json_escape("test\rme"));
+	EXPECT_EQ("test\\tme", test_json_escape("test\tme"));
+}
+
+TEST(JsonEscapeTest, StringWithNonPrintableAsciiCharacters) {
+	EXPECT_EQ("test\\u000bme", test_json_escape("test\013me"));
+	EXPECT_EQ("test\\u0016me", test_json_escape("test\026me"));
+	EXPECT_EQ("test\\u001bme", test_json_escape("test\033me"));
+}
+
+TEST(JsonEscapeTest, StringWithNullCharacter) {
+	EXPECT_EQ("test\\u0000me", test_json_escape(std::string("test\0me", 7)));
+}
+
+}  // namespace loki::detail

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
 int main(int argc, char **argv) {
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+	testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
* more sophisticated escaping for strings before putting them in JSON (now with unit tests)
* reset the log lines cursor after pushing the log lines
* for JSON agent, fixed up the check for if there is anything to push at all (note: protobuf agent does not have such a check at all, but it should probably have one)
* re-ran clang-format on the codebase
We are not using protobuf agent, so can't tell how functional it is.